### PR TITLE
(#7) Add dependency on compatibility package in core packgage

### DIFF
--- a/src/chocolatey-core.extension/CHANGELOG.md
+++ b/src/chocolatey-core.extension/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.3.6
 
 - Bugfix: Expand all aliases used in helper scripts ([#8](https://github.com/chocolatey-community/chocolatey-extensions/issues/8))
+- Add dependency of compatibility packages to prevent breaking changes ([#7](https://github.com/chocolatey-community/chocolatey-extensions/issues/7))
 
 ## 1.3.5
 

--- a/src/chocolatey-core.extension/chocolatey-core.extension.nuspec
+++ b/src/chocolatey-core.extension/chocolatey-core.extension.nuspec
@@ -22,6 +22,9 @@ These functions may be used in Chocolatey install/uninstall scripts by declaring
     <docsUrl>https://github.com/chocolatey-community/chocolatey-extensions/blob/master/src/chocolatey-core.extension/README.md</docsUrl>
     <bugTrackerUrl>https://github.com/chocolatey-community/chocolatey-extensions/issues</bugTrackerUrl>
     <releaseNotes>https://github.com/chocolatey-community/chocolatey-extensions/blob/master/src/chocolatey-core.extension/CHANGELOG.md</releaseNotes>
+    <dependencies>
+      <dependency id="chocolatey-compatibility.extension" version="1.0.0" />
+    </dependencies>
     </metadata>
     <files>
     <file src="extensions\**" target="extensions" />


### PR DESCRIPTION
This pull request updates the chocolatey-core.extension package to provide a dependency on chocolatey-compatibility.extension to ensure that a future change do not break the existing use of the package.

This PR requires the PRs #4 and #9 to be merged first, and this PR to be rebased afterwards.

fixes #7

https://app.clickup.com/t/20540031/ENGTASKS-1204

https://app.clickup.com/t/20540031/ENGTASKS-1186