### PR TITLE
(fix) Ensure PS v2 compatibility

### DIFF
--- a/src/chocolatey-compatibility.extension/extensions/chocolatey-compatibility.psm1
+++ b/src/chocolatey-compatibility.extension/extensions/chocolatey-compatibility.psm1
@@ -7,7 +7,7 @@ $ScriptRoot = Split-Path $MyInvocation.MyCommand.Definition
 # we need to check the file system directly.
 $ChocolateyScriptPath = Resolve-Path "$env:ChocolateyInstall\helpers\functions"
 
-$existingMembers = Get-ChildItem $ChocolateyScriptPath | ForEach-Object BaseName
+$existingMembers = Get-ChildItem $ChocolateyScriptPath | ForEach-Object { $_.BaseName }
 
 Get-ChildItem "$ScriptRoot\helpers\*.ps1" | `
   Where-Object { $_.Name -cmatch "^[A-Z]+" } | `


### PR DESCRIPTION
The current code does not work in PowerShell v2.

![image](https://github.com/chocolatey-community/chocolatey-extensions/assets/12760779/f1d275da-ce59-4f17-99eb-4a31b6df59e9)

This change ensures it does.

![image](https://github.com/chocolatey-community/chocolatey-extensions/assets/12760779/705684d2-52f4-4767-b24c-c36d5398a2de)
